### PR TITLE
Fix mapinfo fixes for MapFormat

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -150,7 +150,7 @@ static void ActivateLine(AActor* mo, line_s* line, byte side,
 	{
 	case LineCross:
 		if (line)
-			P_CrossSpecialLine(line - lines, side, mo, bossaction);
+			P_CrossSpecialLine(line, side, mo, bossaction);
 		break;
 	case LineUse:
 		if (line)

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -2088,7 +2088,7 @@ lineresult_s P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		/* Exit level
 		 * killough 10/98: prevent zombies from exiting levels
 		 */
-		if (!bossaction && thing->player && thing->player->health <= 0)
+		if (!bossaction && thing && thing->player && thing->player->health <= 0)
 		{
 			return result;
 		}
@@ -2212,7 +2212,7 @@ lineresult_s P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		/* Secret EXIT
 		 * killough 10/98: prevent zombies from exiting levels
 		 */
-		if (!bossaction && thing->player && thing->player->health <= 0)
+		if (!bossaction && thing && thing->player && thing->player->health <= 0)
 		{
 			return result;
 		}
@@ -3388,7 +3388,7 @@ lineresult_s P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		case 197:
 			// Exit to next level
 			// killough 10/98: prevent zombies from exiting levels
-			if (thing->player && thing->player->health <= 0)
+			if (thing && thing->player && thing->player->health <= 0)
 				break;
 			if (thing && CheckIfExitIsGood(thing))
 			{
@@ -3401,7 +3401,7 @@ lineresult_s P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		case 198:
 			// Exit to secret level
 			// killough 10/98: prevent zombies from exiting levels
-			if (thing->player && thing->player->health <= 0)
+			if (thing && thing->player && thing->player->health <= 0)
 				break;
 			if (thing && CheckIfExitIsGood(thing))
 			{

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -1825,9 +1825,8 @@ lineresult_s P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 
 	// e6y
 	// b.m. side test was broken in boom201
-	if (demoplayback)
-		if (side) // jff 6/1/98 fix inadvertent deletion of side test
-			return result;
+	if (side) // jff 6/1/98 fix inadvertent deletion of side test
+		return result;
 
 	// jff 02/04/98 add check here for generalized floor/ceil mover
 	

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -244,7 +244,7 @@ lineresult_s P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			ok = 1;
 			break;
 		}
-		if (!ok)
+		if (!ok && !bossaction) // Bossactions can use any linedef except teleports.
 			return result;
 	}
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2738,7 +2738,7 @@ void A_BossDeath(AActor *actor)
 				}
 
 				if (!P_UseSpecialLine(actor, &ld, 0, true))
-					P_CrossSpecialLine(0, 0, actor, true);
+					P_CrossSpecialLine(&ld, 0, actor, true);
 			}
 		}
 	}

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -1019,6 +1019,7 @@ BOOL EV_DoGenFloor(line_t* line)
 		if (manual)
 			return rtn;
 	}
+	return rtn;
 }
 
 BOOL EV_DoZDoomFloor(DFloor::EFloor floortype, line_t* line, int tag, fixed_t speed,

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -1254,7 +1254,7 @@ BOOL P_TryMove (AActor *thing, fixed_t x, fixed_t y,
 			int side = P_PointOnLineSide (thing->x, thing->y, ld);
 			int oldside = P_PointOnLineSide (oldx, oldy, ld);
 			if (side != oldside && ld->special)
-				P_CrossSpecialLine (ld-lines, oldside, thing, false);
+				P_CrossSpecialLine (ld, oldside, thing, false);
 		}
 	}
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1901,10 +1901,8 @@ bool P_HandleSpecialRepeat(line_t* line)
 // Called every time a thing origin is about
 //  to cross a line with a non 0 special.
 //
-void P_CrossSpecialLine(int	linenum, int side, AActor* thing, bool bossaction)
+void P_CrossSpecialLine(line_t*	line, int side, AActor* thing, bool bossaction)
 {
-    line_t*	line = &lines[linenum];
-
 	TeleportSide = side;
 
 	if (!bossaction && !P_CanActivateSpecials(thing, line))

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -330,7 +330,7 @@ void	P_SpawnZDoomSectorSpecials (void);
 void	P_UpdateSpecials (void);
 
 // when needed
-void    P_CrossSpecialLine (int linenum, int side, AActor* thing, bool bossaction);
+void    P_CrossSpecialLine (line_t* line, int side, AActor* thing, bool bossaction);
 void    P_ShootSpecialLine (AActor* thing, line_t* line);
 bool    P_UseSpecialLine (AActor* thing, line_t* line, int side, bool bossaction);
 bool    P_PushSpecialLine (AActor* thing, line_t* line, int	side);


### PR DESCRIPTION
The following fixes will at least make MAP07 playable. Other bossactions (E3M8 Spider, for example) seem to be incomplete as they are recording 0 special and 0 tag.